### PR TITLE
fix: load Princeton chapter events only

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ layout: col-sidebar
 title: OWASP Princeton
 region: North America
 country: USA
-meetup-group: https://www.meetup.com/owasp-princeton-chapter/
+meetup-group: owasp-princeton-chapter
 
 ---
 


### PR DESCRIPTION
As shown in the image below, this change fetches only Princeton chapter events from Meetup.

![image](https://github.com/user-attachments/assets/e039bfc1-4949-49bd-b136-ae0b79e37d15)
